### PR TITLE
Update badlands_mining.json to fix badlands loot table

### DIFF
--- a/common/src/main/resources/data/abridged/loot_tables/chests/badlands_mining.json
+++ b/common/src/main/resources/data/abridged/loot_tables/chests/badlands_mining.json
@@ -4,7 +4,7 @@
       "rolls": 1,
       "entries": [
         {
-          "type": "minecraft:loot_table",
+          "type": "minecraft:item",
           "name": "minecraft:anvil"
         },
         {


### PR DESCRIPTION
Fixed anvils not appearing in the badlands loot.

The loot table was attempting to reference another loot table called "minecraft:anvil" (which doesn't exist) and I assume the intention was to call the anvil item instead, so I changed a single line to fix it.